### PR TITLE
feat: BungeeCord support and check total currency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>

--- a/src/main/java/su/nightexpress/coinsengine/CoinsEngine.java
+++ b/src/main/java/su/nightexpress/coinsengine/CoinsEngine.java
@@ -116,6 +116,9 @@ public class CoinsEngine extends NexPlugin<CoinsEngine> implements UserDataHolde
             this.currencyManager.shutdown();
             this.currencyManager = null;
         }
+
+        this.getServer().getMessenger().unregisterOutgoingPluginChannel(this);
+        this.getServer().getMessenger().unregisterIncomingPluginChannel(this);
     }
 
     @Override
@@ -125,6 +128,9 @@ public class CoinsEngine extends NexPlugin<CoinsEngine> implements UserDataHolde
 
         this.userManager = new UserManager(this);
         this.userManager.setup();
+
+        this.getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
+        this.getServer().getMessenger().registerIncomingPluginChannel(this, "BungeeCord", this.dataHandler);
 
         return true;
     }

--- a/src/main/java/su/nightexpress/coinsengine/Placeholders.java
+++ b/src/main/java/su/nightexpress/coinsengine/Placeholders.java
@@ -12,6 +12,7 @@ public class Placeholders extends su.nexmedia.engine.utils.Placeholders {
     public static final String GENERIC_MAX     = "%max%";
     public static final String GENERIC_POS     = "%pos%";
     public static final String GENERIC_STATE   = "%state%";
+    public static final String GENERIC_TOTAL_BALANCE = "%total_balance%";
 
     public static final String CURRENCY_ID     = "%currency_id%";
     public static final String CURRENCY_NAME   = "%currency_name%";

--- a/src/main/java/su/nightexpress/coinsengine/command/currency/CurrencyMainCommand.java
+++ b/src/main/java/su/nightexpress/coinsengine/command/currency/CurrencyMainCommand.java
@@ -17,6 +17,7 @@ public class CurrencyMainCommand extends GeneralCommand<CoinsEngine> {
         this.addChildren(new HelpSubCommand<>(plugin));
         this.addDefaultCommand(new BalanceCommand(plugin, currency));
         this.addChildren(new TopCommand(plugin, currency, "top"));
+        this.addChildren(new TotalCommand(plugin, currency, "total"));
         this.addChildren(new GiveCommand(plugin, currency));
         this.addChildren(new SetCommand(plugin, currency));
         this.addChildren(new TakeCommand(plugin, currency));

--- a/src/main/java/su/nightexpress/coinsengine/command/currency/impl/SendCommand.java
+++ b/src/main/java/su/nightexpress/coinsengine/command/currency/impl/SendCommand.java
@@ -104,14 +104,11 @@ public class SendCommand extends CurrencySubCommand {
             .replace(Placeholders.PLAYER_NAME, userTarget.getName())
             .send(sender);
 
-        Player pTarget = plugin.getServer().getPlayer(userTarget.getName());
-        if (pTarget != null) {
-            plugin.getMessage(Lang.COMMAND_CURRENCY_SEND_DONE_NOTIFY)
+        plugin.getMessage(Lang.COMMAND_CURRENCY_SEND_DONE_NOTIFY)
                 .replace(currency.replacePlaceholders())
                 .replace(Placeholders.GENERIC_AMOUNT, currency.format(amount))
                 .replace(Placeholders.GENERIC_BALANCE, dataTarget.getBalance())
                 .replace(Placeholders.PLAYER_NAME, userFrom.getName())
-                .send(pTarget);
-        }
+                .send(userTarget.getName());
     }
 }

--- a/src/main/java/su/nightexpress/coinsengine/command/currency/impl/TotalCommand.java
+++ b/src/main/java/su/nightexpress/coinsengine/command/currency/impl/TotalCommand.java
@@ -1,0 +1,38 @@
+package su.nightexpress.coinsengine.command.currency.impl;
+
+import com.google.common.util.concurrent.AtomicDouble;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import su.nexmedia.engine.api.command.CommandResult;
+import su.nexmedia.engine.utils.Pair;
+import su.nightexpress.coinsengine.CoinsEngine;
+import su.nightexpress.coinsengine.Placeholders;
+import su.nightexpress.coinsengine.api.currency.Currency;
+import su.nightexpress.coinsengine.command.currency.CurrencySubCommand;
+import su.nightexpress.coinsengine.config.Lang;
+import su.nightexpress.coinsengine.config.Perms;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TotalCommand extends CurrencySubCommand {
+
+    public TotalCommand(@NotNull CoinsEngine plugin, @NotNull Currency currency, @NotNull String... aliases) {
+        super(plugin, currency, aliases, Perms.COMMAND_CURRENCY_TOTAL);
+        this.setDescription(plugin.getMessage(Lang.COMMAND_CURRENCY_TOTAL_TOP_DESC));
+    }
+
+    @Override
+    protected void onExecute(@NotNull CommandSender sender, @NotNull CommandResult result) {
+        List<Pair<String, Double>> full = this.plugin.getCurrencyManager().getBalanceMap().getOrDefault(this.currency, Collections.emptyList());
+
+        AtomicDouble totalCurrency = new AtomicDouble(0);
+        full.forEach((pair) -> totalCurrency.addAndGet(pair.getSecond()));
+        String totalCurrencyFormat = currency.format(totalCurrency.get());
+
+        this.plugin.getMessage(Lang.COMMAND_CURRENCY_TOTAL_TOP_DONE)
+            .replace(currency.replacePlaceholders())
+            .replace(Placeholders.GENERIC_TOTAL_BALANCE, totalCurrencyFormat)
+            .send(sender);
+    }
+}

--- a/src/main/java/su/nightexpress/coinsengine/config/Lang.java
+++ b/src/main/java/su/nightexpress/coinsengine/config/Lang.java
@@ -69,6 +69,8 @@ public class Lang extends EngineLang {
             "\n" + GRAY + "Page " + CYAN + GENERIC_CURRENT + GRAY + " of " + CYAN + GENERIC_MAX + GRAY + "." +
             "\n" + CYAN);
 
+    public static final LangKey COMMAND_CURRENCY_TOTAL_TOP_DESC = LangKey.of("Command.Currency.Total.Desc", "Check total currency assets.");
+    public static final LangKey COMMAND_CURRENCY_TOTAL_TOP_DONE = LangKey.of("Command.Currency.Total.Done", LIGHT_YELLOW + "Total " + CURRENCY_NAME + ": " + ORANGE + GENERIC_TOTAL_BALANCE);
     public static final LangKey CURRENCY_BALANCE_DISPLAY_OWN    = LangKey.of("Currency.Balance.Display.Own", LIGHT_YELLOW + "Balance: " + ORANGE + GENERIC_BALANCE + LIGHT_YELLOW + ".");
     public static final LangKey CURRENCY_BALANCE_DISPLAY_OTHERS = LangKey.of("Currency.Balance.Display.Others", ORANGE + PLAYER_NAME + LIGHT_YELLOW + "'s balance: " + ORANGE + GENERIC_BALANCE + LIGHT_YELLOW + ".");
 

--- a/src/main/java/su/nightexpress/coinsengine/config/Perms.java
+++ b/src/main/java/su/nightexpress/coinsengine/config/Perms.java
@@ -20,6 +20,7 @@ public class Perms {
     public static final JPermission COMMAND_CURRENCY_PAYMENTS        = new JPermission(PREFIX_COMMAND + "currency.payments");
     public static final JPermission COMMAND_CURRENCY_PAYMENTS_OTHERS = new JPermission(PREFIX_COMMAND + "currency.payments.others");
     public static final JPermission COMMAND_CURRENCY_TOP             = new JPermission(PREFIX_COMMAND + "currency.top");
+    public static final JPermission COMMAND_CURRENCY_TOTAL             = new JPermission(PREFIX_COMMAND + "currency.total");
     public static final JPermission COMMAND_CURRENCY_SEND            = new JPermission(PREFIX_COMMAND + "currency.send");
     public static final JPermission COMMAND_CURRENCY_SET             = new JPermission(PREFIX_COMMAND + "currency.set");
     public static final JPermission COMMAND_CURRENCY_TAKE            = new JPermission(PREFIX_COMMAND + "currency.take");


### PR DESCRIPTION
This is a great economical plugin. I supported BungeeCord in this Pull Request.

- Balances will be refreshed quickly. No need to enable `Sync_Interval` in config.yml.
- Added payment notifications for players on other bungeecord servers. (Command `/pay`)
- Check total currency assets. (Example: `/coins total`)

NexEngine needs to be review this [Pull Request](https://github.com/nulli0n/NexEngine-spigot/pull/49) before merging this branch. Because it does not support sending [BungeeCord messages](https://www.spigotmc.org/wiki/bukkit-bungee-plugin-messaging-channel/#messageraw)
