### PR TITLE
Add currency short/compact formatting

### DIFF
--- a/src/main/java/su/nightexpress/coinsengine/Placeholders.java
+++ b/src/main/java/su/nightexpress/coinsengine/Placeholders.java
@@ -16,5 +16,6 @@ public class Placeholders extends su.nexmedia.engine.utils.Placeholders {
     public static final String CURRENCY_ID     = "%currency_id%";
     public static final String CURRENCY_NAME   = "%currency_name%";
     public static final String CURRENCY_SYMBOL = "%currency_symbol%";
+    public static final String CURRENCY_SHORT_SYMBOL = "%currency_short_symbol%";
 
 }

--- a/src/main/java/su/nightexpress/coinsengine/api/currency/Currency.java
+++ b/src/main/java/su/nightexpress/coinsengine/api/currency/Currency.java
@@ -4,6 +4,7 @@ import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import su.nexmedia.engine.api.placeholder.Placeholder;
 import su.nexmedia.engine.utils.NumberUtil;
+import su.nexmedia.engine.utils.Pair;
 import su.nightexpress.coinsengine.Placeholders;
 import su.nightexpress.coinsengine.config.Perms;
 
@@ -58,6 +59,19 @@ public interface Currency extends Placeholder {
         return this.replacePlaceholders().apply(this.getFormat()).replace(Placeholders.GENERIC_AMOUNT, this.formatValue(balance));
     }
 
+    @NotNull
+    default Pair<String, String> formatCompactValue(double balance) {
+        return NumberUtil.formatCompact(this.fine(balance));
+    }
+
+    @NotNull
+    default String formatCompact(double balance) {
+        Pair<String, String> compact = this.formatCompactValue(balance);
+        return this.replacePlaceholders().apply(this.getFormatShort())
+                .replace(Placeholders.GENERIC_AMOUNT, compact.getFirst())
+                .replace(Placeholders.CURRENCY_SHORT_SYMBOL, compact.getSecond());
+    }
+
     @NotNull String getId();
 
     @NotNull String getName();
@@ -70,7 +84,11 @@ public interface Currency extends Placeholder {
 
     @NotNull String getFormat();
 
+    @NotNull String getFormatShort();
+
     void setFormat(@NotNull String format);
+
+    void setFormatShort(@NotNull String formatShort);
 
     @NotNull String[] getCommandAliases();
 

--- a/src/main/java/su/nightexpress/coinsengine/currency/CurrencyManager.java
+++ b/src/main/java/su/nightexpress/coinsengine/currency/CurrencyManager.java
@@ -161,6 +161,7 @@ public class CurrencyManager extends AbstractManager<CoinsEngine> {
         ConfigCurrency currency = new ConfigCurrency(this.plugin, cfg);
         currency.setName(StringUtil.capitalizeUnderscored(id));
         currency.setFormat(Placeholders.GENERIC_AMOUNT + Placeholders.CURRENCY_SYMBOL);
+        currency.setFormatShort(Placeholders.CURRENCY_SYMBOL + Placeholders.GENERIC_AMOUNT + Placeholders.CURRENCY_SHORT_SYMBOL);
         currency.setCommandAliases(new String[]{id});
         currency.setPermissionRequired(false);
         currency.setTransferAllowed(true);

--- a/src/main/java/su/nightexpress/coinsengine/currency/impl/ConfigCurrency.java
+++ b/src/main/java/su/nightexpress/coinsengine/currency/impl/ConfigCurrency.java
@@ -22,6 +22,7 @@ public class ConfigCurrency extends AbstractConfigHolder<CoinsEngine> implements
     private String name;
     private String symbol;
     private String format;
+    private String formatShort;
     private String[] commandAliases;
     private ItemStack icon;
     private boolean decimal;
@@ -60,6 +61,14 @@ public class ConfigCurrency extends AbstractConfigHolder<CoinsEngine> implements
             "Currency display format.",
             "Use '" + Placeholders.GENERIC_AMOUNT + "' placeholder for amount value.",
             "You can use 'Currency' placeholders: " + Placeholders.WIKI_PLACEHOLDERS
+        ).read(cfg));
+
+        this.setFormatShort(JOption.create("Format_Short",
+                Placeholders.CURRENCY_SYMBOL + Placeholders.GENERIC_AMOUNT + Placeholders.CURRENCY_SHORT_SYMBOL,
+                "Currency short display format.",
+                "Use '" + Placeholders.GENERIC_AMOUNT + "' placeholder for amount value.",
+                "Use '" + Placeholders.CURRENCY_SHORT_SYMBOL + "' placeholder for short symbol (k, m, b, t, q).",
+                "You can use 'Currency' placeholders: " + Placeholders.WIKI_PLACEHOLDERS
         ).read(cfg));
 
         this.setCommandAliases(JOption.create("Command_Aliases",
@@ -124,6 +133,7 @@ public class ConfigCurrency extends AbstractConfigHolder<CoinsEngine> implements
         cfg.set("Name", this.getName());
         cfg.set("Symbol", this.getSymbol());
         cfg.set("Format", this.getFormat());
+        cfg.set("Format_Short", this.getFormatShort());
         cfg.set("Command_Aliases", String.join(",", Arrays.asList(this.getCommandAliases())));
         cfg.setItem("Icon", this.getIcon());
         cfg.set("Decimal", this.isDecimal());
@@ -174,9 +184,20 @@ public class ConfigCurrency extends AbstractConfigHolder<CoinsEngine> implements
         return format;
     }
 
+    @NotNull
+    @Override
+    public String getFormatShort() {
+        return this.formatShort;
+    }
+
     @Override
     public void setFormat(@NotNull String format) {
         this.format = Colorizer.apply(format);
+    }
+
+    @Override
+    public void setFormatShort(@NotNull String formatShort) {
+        this.formatShort = Colorizer.apply(formatShort);
     }
 
     @NotNull

--- a/src/main/java/su/nightexpress/coinsengine/hook/PlaceholderAPIHook.java
+++ b/src/main/java/su/nightexpress/coinsengine/hook/PlaceholderAPIHook.java
@@ -138,12 +138,7 @@ public class PlaceholderAPIHook {
                 Currency currency = plugin.getCurrencyManager().getCurrency(currencyId);
                 if (currency == null) return null;
 
-                double balance = currency.fine(user.getCurrencyData(currency).getBalance());
-
-                NumberFormat fmt = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
-                fmt.setMinimumFractionDigits(1);
-                fmt.setMaximumFractionDigits(2);
-                return fmt.format(balance);
+                return currency.formatCompact(user.getCurrencyData(currency).getBalance());
             }
             // balance_coins
             if (holder.startsWith("balance_")) {


### PR DESCRIPTION
This goes along with: https://github.com/nulli0n/NexEngine-spigot/pull/50
Some examples: 
1,000$ -> $1k
10,100$ -> $10.1k
100,100$ -> $100.1k
1,100,100$ -> $1.1m
123.456.789$ -> $123.46m (rounded)