### PR TITLE
Update DeluxeCoinflip API and make hooks fail-fast

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.github.ItsLewizzz</groupId>
             <artifactId>DeluxeCoinflipAPI</artifactId>
-            <version>1.0.2</version>
+            <version>master</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/su/nightexpress/coinsengine/CoinsEngine.java
+++ b/src/main/java/su/nightexpress/coinsengine/CoinsEngine.java
@@ -20,6 +20,8 @@ import su.nightexpress.coinsengine.hook.DeluxeCoinflipHook;
 import su.nightexpress.coinsengine.hook.HookId;
 import su.nightexpress.coinsengine.hook.PlaceholderAPIHook;
 
+import java.util.logging.Level;
+
 public class CoinsEngine extends NexPlugin<CoinsEngine> implements UserDataHolder<CoinsEngine, CoinsUser> {
 
     private CurrencyManager currencyManager;
@@ -35,7 +37,11 @@ public class CoinsEngine extends NexPlugin<CoinsEngine> implements UserDataHolde
     @Override
     public void enable() {
         this.currencyManager = new CurrencyManager(this);
-        this.currencyManager.setup();
+        try {
+            this.currencyManager.setup();
+        } catch (Exception ex) {
+            this.getLogger().log(Level.WARNING, "Failed to setup currency manager", ex);
+        }
 
         /*this.getCurrencyManager().getVaultCurrency().ifPresent((currency) -> {
             int count = 0;
@@ -99,12 +105,20 @@ public class CoinsEngine extends NexPlugin<CoinsEngine> implements UserDataHolde
         }*/
 
         if (EngineUtils.hasPlaceholderAPI()) {
-            PlaceholderAPIHook.setup(this);
+            try {
+                PlaceholderAPIHook.setup(this);
+            } catch (Exception ex) {
+                this.getLogger().log(Level.WARNING, "Failed to setup PlaceholderAPI hook", ex);
+            }
         }
 
         if (EngineUtils.hasPlugin(HookId.DELUXE_COINFLIP)) {
             this.runTask(task -> {
-                DeluxeCoinflipHook.setup(this);
+                try {
+                    DeluxeCoinflipHook.setup(this);
+                } catch (Exception ex) {
+                    this.getLogger().log(Level.WARNING, "Failed to setup DeluxeCoinflip hook", ex);
+                }
             });
         }
     }

--- a/src/main/java/su/nightexpress/coinsengine/hook/DeluxeCoinflipHook.java
+++ b/src/main/java/su/nightexpress/coinsengine/hook/DeluxeCoinflipHook.java
@@ -1,7 +1,7 @@
 package su.nightexpress.coinsengine.hook;
 
-import fun.lewisdev.deluxecoinflip.api.DeluxeCoinflipAPI;
-import fun.lewisdev.deluxecoinflip.economy.provider.EconomyProvider;
+import net.zithium.deluxecoinflip.api.DeluxeCoinflipAPI;
+import net.zithium.deluxecoinflip.economy.provider.EconomyProvider;
 import org.bukkit.OfflinePlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -39,6 +39,11 @@ public class DeluxeCoinflipHook {
         @Nullable
         private CoinsUser getUser(@NotNull OfflinePlayer offlinePlayer) {
             return this.plugin.getUserManager().getUserData(offlinePlayer.getUniqueId());
+        }
+
+        @Override
+        public void onEnable() {
+            this.plugin.getLogger().info("DeluxeCoinflip hook loaded!");
         }
 
         @Override


### PR DESCRIPTION
This will allow the plugin to load even if one of the hooks fails.