### PR TITLE
Improve MySQL balance consistency across multiple servers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
     maven("https://jitpack.io")
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
     maven("https://repo.rosewooddev.io/repository/public/")
+    mavenLocal()
 }
 
 dependencies {
@@ -27,7 +28,7 @@ dependencies {
     compileOnly("com.github.MilkBowl:VaultAPI:1.7") {
         exclude(group = "org.bukkit", module = "bukkit")
     }
-    compileOnly("su.nightexpress.nightcore:main:2.15.1")
+    compileOnly("su.nightexpress.nightcore:main:2.16.1")
     compileOnly("me.clip:placeholderapi:2.11.6")
     compileOnly("org.black_ixx:playerpoints:3.0.0")
 }

--- a/src/main/java/su/nightexpress/excellenteconomy/ExcellentEconomyProvider.java
+++ b/src/main/java/su/nightexpress/excellenteconomy/ExcellentEconomyProvider.java
@@ -121,8 +121,8 @@ public class ExcellentEconomyProvider implements ExcellentEconomyAPI {
     @Override
     @NonNull
     public CompletableFuture<Double> getBalanceAsync(@NonNull UUID playerId, @NonNull ExcellentCurrency currency) {
-        return this.userManager().loadByIdAsync(playerId).thenApply(opt -> opt.map(user -> user.getBalance(currency))
-            .orElse(0D));
+        return this.userManager().loadByIdAsync(playerId).thenApply(opt -> opt.map(user -> this.currencyManager()
+            .getFreshBalance(user, currency)).orElse(0D));
     }
 
     @Override
@@ -132,7 +132,7 @@ public class ExcellentEconomyProvider implements ExcellentEconomyAPI {
 
     @Override
     public double getBalance(@NonNull Player player, @NonNull ExcellentCurrency currency) {
-        return this.getCachedUserData(player).getBalance(currency);
+        return this.currencyManager().getFreshBalance(this.getCachedUserData(player), currency);
     }
 
 
@@ -218,7 +218,7 @@ public class ExcellentEconomyProvider implements ExcellentEconomyAPI {
     public CompletableFuture<OperationResult> withdrawAsync(@NonNull UUID playerId, @NonNull ExcellentCurrency currency,
                                                             double amount, @NonNull OperationContext context) {
         return this.userManager().loadByIdAsync(playerId)
-            .thenApply(opt -> opt.map(user -> this.currencyManager().remove(context, user, currency, amount)).orElse(
+            .thenApply(opt -> opt.map(user -> this.currencyManager().withdraw(context, user, currency, amount)).orElse(
                 OperationResult.FAILURE));
     }
 
@@ -242,7 +242,8 @@ public class ExcellentEconomyProvider implements ExcellentEconomyAPI {
     @Override
     public boolean withdraw(@NonNull Player player, @NonNull ExcellentCurrency currency, double amount,
                             @NonNull OperationContext context) {
-        return this.currencyManager().remove(context, player, currency, amount) == OperationResult.SUCCESS;
+        return this.currencyManager().withdraw(context, this.userManager().getOrFetch(player), currency, amount) ==
+            OperationResult.SUCCESS;
     }
 
 

--- a/src/main/java/su/nightexpress/excellenteconomy/currency/CurrencyManager.java
+++ b/src/main/java/su/nightexpress/excellenteconomy/currency/CurrencyManager.java
@@ -81,6 +81,7 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
         this.plugin.addGlobalPlaceholders(new PlayerBalancePlaceholders(this.registry, this));
 
         FileUtil.findYamlFiles(this.getDirectory()).forEach(this::loadCurrency);
+        this.dataHandler.ensureUserIntegrity(this.registry.getCurrencies());
 
         try {
             this.loadLogger();
@@ -410,7 +411,7 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
             sender) ? Lang.CURRENCY_BALANCE_DISPLAY_OWN : Lang.CURRENCY_BALANCE_DISPLAY_OTHERS), sender,
             builder -> builder
                 .with(CommonPlaceholders.PLAYER_NAME, user::getName)
-                .with(EconomyPlaceholders.GENERIC_BALANCE, () -> currency.format(user.getBalance(currency)))
+                .with(EconomyPlaceholders.GENERIC_BALANCE, () -> currency.format(this.getFreshBalance(user, currency)))
         );
     }
 
@@ -466,6 +467,14 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
         return user.getBalance(currency);
     }
 
+    public double getFreshBalance(@NonNull CoinsUser user, @NonNull ExcellentCurrency currency) {
+        double balance = this.dataHandler.fetchBalance(user.getId(), currency).orElse(user.getBalance(currency));
+        if (this.dataHandler.isAtomicBalances()) {
+            user.getBalance().set(currency, balance);
+        }
+        return balance;
+    }
+
     @NonNull
     public OperationResult give(@NonNull OperationContext context, @NonNull Player player,
                                 @NonNull ExcellentCurrency currency, double amount) {
@@ -479,8 +488,20 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
 
         OperationExecutor executor = context.getExecutor();
 
-        user.addBalance(currency, amount);
-        user.markDirty();
+        double oldBalance = user.getBalance(currency);
+        if (!user.tryAddBalance(currency, amount)) return OperationResult.FAILURE;
+
+        if (this.dataHandler.isAtomicBalances()) {
+            DataHandler.BalanceResult result = this.dataHandler.addBalance(user, currency, amount);
+            if (!result.success()) {
+                user.getBalance().set(currency, oldBalance);
+                return OperationResult.FAILURE;
+            }
+            user.getBalance().set(currency, result.balance());
+        }
+        else {
+            user.markDirty();
+        }
 
         if (this.logger != null && context.shouldNotifyLogger()) {
             this.logger.addEntry(context, "[%s] %s gave %s to %s. New balance: %s"
@@ -524,8 +545,20 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
             Player target = user.player().orElse(null);
             if (target == null) return; // Only online players should be affected.
 
-            user.addBalance(currency, amount);
-            user.markDirty();
+            double oldBalance = user.getBalance(currency);
+            if (!user.tryAddBalance(currency, amount)) return;
+
+            if (this.dataHandler.isAtomicBalances()) {
+                DataHandler.BalanceResult result = this.dataHandler.addBalance(user, currency, amount);
+                if (!result.success()) {
+                    user.getBalance().set(currency, oldBalance);
+                    return;
+                }
+                user.getBalance().set(currency, result.balance());
+            }
+            else {
+                user.markDirty();
+            }
 
             if (context.shouldNotify(NotificationTarget.USER)) {
                 currency.sendPrefixed(Lang.COMMAND_CURRENCY_GIVE_NOTIFY, target, builder -> builder
@@ -565,8 +598,20 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
 
         OperationExecutor executor = context.getExecutor();
 
-        user.removeBalance(currency, amount);
-        user.markDirty();
+        double oldBalance = user.getBalance(currency);
+        if (!user.tryRemoveBalance(currency, amount)) return OperationResult.FAILURE;
+
+        if (this.dataHandler.isAtomicBalances()) {
+            DataHandler.BalanceResult result = this.dataHandler.removeBalance(user, currency, amount);
+            if (!result.success()) {
+                user.getBalance().set(currency, oldBalance);
+                return OperationResult.FAILURE;
+            }
+            user.getBalance().set(currency, result.balance());
+        }
+        else {
+            user.markDirty();
+        }
 
         if (this.logger != null && context.shouldNotifyLogger()) {
             this.logger.addEntry(context, "[%s] %s took %s from %s's balance. New balance: %s"
@@ -597,6 +642,50 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
     }
 
     @NonNull
+    public OperationResult withdraw(@NonNull OperationContext context, @NonNull CoinsUser user,
+                                    @NonNull ExcellentCurrency currency, double amount) {
+        if (!this.assertOperationsEnabled(context)) return OperationResult.FAILURE;
+
+        double currentBalance = this.getFreshBalance(user, currency);
+        user.getBalance().set(currency, currentBalance);
+
+        if (currentBalance < Math.abs(amount)) {
+            return OperationResult.FAILURE;
+        }
+
+        double oldBalance = user.getBalance(currency);
+        if (!user.tryRemoveBalance(currency, amount)) return OperationResult.FAILURE;
+
+        if (this.dataHandler.isAtomicBalances()) {
+            DataHandler.BalanceResult result = this.dataHandler.withdrawBalance(user, currency, amount);
+            if (!result.success()) {
+                user.getBalance().set(currency, result.status() == DataHandler.BalanceStatus.INSUFFICIENT_FUNDS
+                    ? result.balance()
+                    : oldBalance);
+                return OperationResult.FAILURE;
+            }
+            user.getBalance().set(currency, result.balance());
+        }
+        else {
+            user.markDirty();
+        }
+
+        return OperationResult.SUCCESS;
+    }
+
+    public void persistBalance(@NonNull CoinsUser user, @NonNull ExcellentCurrency currency) {
+        if (this.dataHandler.isAtomicBalances()) {
+            DataHandler.BalanceResult result = this.dataHandler.setBalance(user, currency, user.getBalance(currency));
+            if (result.success()) {
+                user.getBalance().set(currency, result.balance());
+            }
+            return;
+        }
+
+        user.markDirty();
+    }
+
+    @NonNull
     public OperationResult set(@NonNull OperationContext context, @NonNull Player player,
                                @NonNull ExcellentCurrency currency, double amount) {
         return this.set(context, this.userManager.getOrFetch(player), currency, amount);
@@ -609,8 +698,20 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
 
         OperationExecutor executor = context.getExecutor();
 
-        user.setBalance(currency, amount);
-        user.markDirty();
+        double oldBalance = user.getBalance(currency);
+        if (!user.trySetBalance(currency, amount)) return OperationResult.FAILURE;
+
+        if (this.dataHandler.isAtomicBalances()) {
+            DataHandler.BalanceResult result = this.dataHandler.setBalance(user, currency, user.getBalance(currency));
+            if (!result.success()) {
+                user.getBalance().set(currency, oldBalance);
+                return OperationResult.FAILURE;
+            }
+            user.getBalance().set(currency, result.balance());
+        }
+        else {
+            user.markDirty();
+        }
 
         if (this.logger != null && context.shouldNotifyLogger()) {
             this.logger.addEntry(context, "[%s] %s set %s's balance to %s. New balance: %s"
@@ -654,8 +755,20 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
 
         OperationExecutor executor = context.getExecutor();
 
-        user.resetBalance(currency);
-        user.markDirty();
+        double oldBalance = user.getBalance(currency);
+        if (!user.tryResetBalance(currency)) return OperationResult.FAILURE;
+
+        if (this.dataHandler.isAtomicBalances()) {
+            DataHandler.BalanceResult result = this.dataHandler.setBalance(user, currency, user.getBalance(currency));
+            if (!result.success()) {
+                user.getBalance().set(currency, oldBalance);
+                return OperationResult.FAILURE;
+            }
+            user.getBalance().set(currency, result.balance());
+        }
+        else {
+            user.markDirty();
+        }
 
         if (this.logger != null && context.shouldNotifyLogger()) {
             this.logger.addEntry(context, "[%s] %s reset %s's balance of %s to %s."
@@ -707,6 +820,12 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
         }
 
         CoinsUser fromUser = this.userManager.getOrFetch(sender);
+
+        if (this.dataHandler.isAtomicBalances()) {
+            this.dataHandler.fetchBalance(fromUser.getId(), currency).ifPresent(balance -> fromUser.getBalance().set(currency, balance));
+            this.dataHandler.fetchBalance(targetUser.getId(), currency).ifPresent(balance -> targetUser.getBalance().set(currency, balance));
+        }
+
         if (amount > fromUser.getBalance(currency)) {
             currency.sendPrefixed(Lang.CURRENCY_SEND_ERROR_NOT_ENOUGH, sender);
             return false;
@@ -720,10 +839,36 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
             return false;
         }
 
-        targetUser.addBalance(currency, amount);
-        targetUser.markDirty();
-        fromUser.removeBalance(currency, amount);
-        fromUser.markDirty();
+        double fromOld = fromUser.getBalance(currency);
+        double targetOld = targetUser.getBalance(currency);
+
+        if (!fromUser.tryRemoveBalance(currency, amount)) return false;
+        if (!targetUser.tryAddBalance(currency, amount)) {
+            fromUser.getBalance().set(currency, fromOld);
+            return false;
+        }
+
+        if (this.dataHandler.isAtomicBalances()) {
+            DataHandler.TransferResult result = this.dataHandler.transfer(fromUser, targetUser, currency, amount);
+            if (!result.success()) {
+                fromUser.getBalance().set(currency, result.status() == DataHandler.BalanceStatus.INSUFFICIENT_FUNDS
+                    ? result.sourceBalance()
+                    : fromOld);
+                targetUser.getBalance().set(currency, targetOld);
+
+                if (result.status() == DataHandler.BalanceStatus.INSUFFICIENT_FUNDS) {
+                    currency.sendPrefixed(Lang.CURRENCY_SEND_ERROR_NOT_ENOUGH, sender);
+                }
+                return false;
+            }
+
+            fromUser.getBalance().set(currency, result.sourceBalance());
+            targetUser.getBalance().set(currency, result.targetBalance());
+        }
+        else {
+            fromUser.markDirty();
+            targetUser.markDirty();
+        }
 
         currency.sendPrefixed(Lang.CURRENCY_SEND_DONE_SENDER, sender, builder -> builder
             .with(EconomyPlaceholders.GENERIC_AMOUNT, () -> currency.format(amount))
@@ -771,6 +916,11 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
         }
 
         CoinsUser user = this.userManager.getOrFetch(player);
+        if (this.dataHandler.isAtomicBalances()) {
+            this.dataHandler.fetchBalance(user.getId(), sourceCurrency).ifPresent(balance -> user.getBalance().set(sourceCurrency, balance));
+            this.dataHandler.fetchBalance(user.getId(), targetCurrency).ifPresent(balance -> user.getBalance().set(targetCurrency, balance));
+        }
+
         if (user.getBalance(sourceCurrency) < amount) {
             sourceCurrency.sendPrefixed(Lang.CURRENCY_EXCHANGE_ERROR_LOW_BALANCE, player, builder -> builder
                 .with(EconomyPlaceholders.GENERIC_AMOUNT, () -> sourceCurrency.format(amount))
@@ -800,9 +950,44 @@ public class CurrencyManager extends AbstractManager<EconomyPlugin> {
             return false;
         }
 
-        user.removeBalance(sourceCurrency, amount);
-        user.addBalance(targetCurrency, result);
-        user.markDirty();
+        double sourceOld = user.getBalance(sourceCurrency);
+        double targetOld = user.getBalance(targetCurrency);
+
+        if (!user.tryRemoveBalance(sourceCurrency, amount)) return false;
+        if (!user.tryAddBalance(targetCurrency, result)) {
+            user.getBalance().set(sourceCurrency, sourceOld);
+            return false;
+        }
+
+        if (this.dataHandler.isAtomicBalances()) {
+            DataHandler.TransferResult operation = this.dataHandler.exchange(user, sourceCurrency, targetCurrency, amount, result);
+            if (!operation.success()) {
+                boolean hasAuthoritativeBalances = operation.status() == DataHandler.BalanceStatus.INSUFFICIENT_FUNDS ||
+                    operation.status() == DataHandler.BalanceStatus.LIMIT_EXCEEDED;
+
+                user.getBalance().set(sourceCurrency, hasAuthoritativeBalances ? operation.sourceBalance() : sourceOld);
+                user.getBalance().set(targetCurrency, hasAuthoritativeBalances ? operation.targetBalance() : targetOld);
+
+                if (operation.status() == DataHandler.BalanceStatus.INSUFFICIENT_FUNDS) {
+                    sourceCurrency.sendPrefixed(Lang.CURRENCY_EXCHANGE_ERROR_LOW_BALANCE, player, builder -> builder
+                        .with(EconomyPlaceholders.GENERIC_AMOUNT, () -> sourceCurrency.format(amount))
+                    );
+                }
+                else if (operation.status() == DataHandler.BalanceStatus.LIMIT_EXCEEDED) {
+                    targetCurrency.sendPrefixed(Lang.CURRENCY_EXCHANGE_ERROR_LIMIT_EXCEED, player, builder -> builder
+                        .with(EconomyPlaceholders.GENERIC_AMOUNT, () -> targetCurrency.format(result))
+                        .with(EconomyPlaceholders.GENERIC_MAX, () -> targetCurrency.format(targetCurrency.getMaxValue()))
+                    );
+                }
+                return false;
+            }
+
+            user.getBalance().set(sourceCurrency, operation.sourceBalance());
+            user.getBalance().set(targetCurrency, operation.targetBalance());
+        }
+        else {
+            user.markDirty();
+        }
 
         sourceCurrency.sendPrefixed(Lang.CURRENCY_EXCHANGE_SUCCESS, player, builder -> builder
             .with(EconomyPlaceholders.GENERIC_BALANCE, () -> sourceCurrency.format(amount))

--- a/src/main/java/su/nightexpress/excellenteconomy/currency/impl/EconomyCurrency.java
+++ b/src/main/java/su/nightexpress/excellenteconomy/currency/impl/EconomyCurrency.java
@@ -129,7 +129,7 @@ public class EconomyCurrency extends AbstractCurrency implements Economy {
     }
 
     private double getBalance(@Nullable CoinsUser user) {
-        return user == null ? 0D : user.getBalance(this);
+        return user == null ? 0D : this.api.dataHandler().fetchBalance(user.getId(), this).orElse(user.getBalance(this));
     }
 
 
@@ -177,7 +177,7 @@ public class EconomyCurrency extends AbstractCurrency implements Economy {
     }
 
     private boolean has(@Nullable CoinsUser user, double amount) {
-        return user != null && user.hasEnough(this, amount);
+        return user != null && this.getBalance(user) >= amount;
     }
 
 
@@ -246,15 +246,11 @@ public class EconomyCurrency extends AbstractCurrency implements Economy {
                 .text());
         }
 
-        if (!user.hasEnough(this, amount)) {
-            return new EconomyResponse(amount, user.getBalance(
-                this), EconomyResponse.ResponseType.FAILURE, Lang.ECONOMY_ERROR_INSUFFICIENT_FUNDS.text());
-        }
-
-        OperationResult result = this.api.currencyManager().remove(this.operationContext(), user, this, amount);
+        OperationResult result = this.api.currencyManager().withdraw(this.operationContext(), user, this, amount);
         EconomyResponse.ResponseType type = result == OperationResult.SUCCESS ? EconomyResponse.ResponseType.SUCCESS : EconomyResponse.ResponseType.FAILURE;
+        String error = result == OperationResult.SUCCESS ? null : Lang.ECONOMY_ERROR_INSUFFICIENT_FUNDS.text();
 
-        return new EconomyResponse(amount, user.getBalance(this), type, null);
+        return new EconomyResponse(amount, user.getBalance(this), type, error);
     }
 
     @NotNull

--- a/src/main/java/su/nightexpress/excellenteconomy/data/DataHandler.java
+++ b/src/main/java/su/nightexpress/excellenteconomy/data/DataHandler.java
@@ -11,6 +11,8 @@ import su.nightexpress.excellenteconomy.user.data.CurrencySettings;
 import su.nightexpress.excellenteconomy.user.data.CurrencySettingsSerializer;
 import su.nightexpress.nightcore.db.AbstractDatabaseManager;
 import su.nightexpress.nightcore.db.column.Column;
+import su.nightexpress.nightcore.db.config.DatabaseType;
+import su.nightexpress.nightcore.db.statement.SQLStatements;
 import su.nightexpress.nightcore.db.statement.condition.Operator;
 import su.nightexpress.nightcore.db.statement.condition.Wheres;
 import su.nightexpress.nightcore.db.statement.template.InsertStatement;
@@ -20,15 +22,26 @@ import su.nightexpress.nightcore.db.table.Table;
 import su.nightexpress.nightcore.user.data.UserDataSchema;
 import su.nightexpress.nightcore.util.TimeUtil;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.OptionalDouble;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class DataHandler extends AbstractDatabaseManager<EconomyPlugin> implements UserDataSchema<CoinsUser> {
 
     public static final Gson GSON = new GsonBuilder().setPrettyPrinting()
         .registerTypeAdapter(CurrencySettings.class, new CurrencySettingsSerializer())
         .create();
+
+    private static final String UUID_INDEX = "idx_execo_users_uuid";
+    private static final String NAME_INDEX = "idx_execo_users_name";
 
     private final Table usersTable;
 
@@ -93,6 +106,416 @@ public class DataHandler extends AbstractDatabaseManager<EconomyPlugin> implemen
         this.addColumn(this.usersTable, DataColumns.forCurrency(currency));
     }
 
+    public boolean isAtomicBalances() {
+        return this.databaseType == DatabaseType.MYSQL;
+    }
+
+    public void ensureUserIntegrity(@NonNull Collection<ExcellentCurrency> currencies) {
+        if (this.databaseType != DatabaseType.MYSQL) return;
+
+        this.mergeDuplicateUsers(currencies);
+        this.ensureIndex(UUID_INDEX, true, DataColumns.USER_UUID);
+        this.ensureIndex(NAME_INDEX, false, DataColumns.USER_NAME);
+    }
+
+    private void ensureIndex(@NonNull String indexName, boolean unique, @NonNull Column<?> column) {
+        if (SQLStatements.hasIndex(this.connector, this.databaseType, this.usersTable.getName(), indexName)) return;
+
+        String sql = "CREATE " + (unique ? "UNIQUE " : "") + "INDEX " + quote(indexName) + " ON " +
+            quote(this.usersTable.getName()) + " (" + quote(column.getName()) + ")";
+        SQLStatements.executeUpdate(this.connector, sql);
+    }
+
+    private void mergeDuplicateUsers(@NonNull Collection<ExcellentCurrency> currencies) {
+        String sql = "SELECT " + quote(DataColumns.USER_UUID.getName()) + " FROM " + quote(this.usersTable.getName()) +
+            " GROUP BY " + quote(DataColumns.USER_UUID.getName()) + " HAVING COUNT(*) > 1";
+
+        try (Connection connection = this.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql);
+             ResultSet resultSet = statement.executeQuery()) {
+
+            while (resultSet.next()) {
+                this.mergeDuplicateUser(resultSet.getString(DataColumns.USER_UUID.getName()), currencies);
+            }
+        }
+        catch (SQLException exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    private void mergeDuplicateUser(@NonNull String uuid, @NonNull Collection<ExcellentCurrency> currencies) {
+        try (Connection connection = this.getConnection()) {
+            boolean autoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+
+            try {
+                MergeState state = this.readDuplicateState(connection, uuid, currencies);
+                if (state == null || state.duplicates() <= 0) {
+                    connection.rollback();
+                    return;
+                }
+
+                this.updateMergedUser(connection, state, currencies);
+                this.deleteDuplicateRows(connection, uuid, state.keepId());
+                connection.commit();
+
+                this.plugin.warn("Merged " + state.duplicates() + " duplicate economy user row(s) for UUID " + uuid + ".");
+            }
+            catch (SQLException exception) {
+                connection.rollback();
+                throw exception;
+            }
+            finally {
+                connection.setAutoCommit(autoCommit);
+            }
+        }
+        catch (SQLException exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    private MergeState readDuplicateState(@NonNull Connection connection,
+                                          @NonNull String uuid,
+                                          @NonNull Collection<ExcellentCurrency> currencies) throws SQLException {
+        String currencyColumns = currencies.stream()
+            .map(currency -> quote(DataColumns.forCurrency(currency).getName()))
+            .collect(Collectors.joining(", "));
+        String currencySelect = currencyColumns.isEmpty() ? "" : ", " + currencyColumns;
+
+        String sql = "SELECT " + quote(DataColumns.ID.getName()) + ", " + quote(DataColumns.USER_NAME.getName()) +
+            ", " + quote(DataColumns.USER_SETTINGS.getName()) + ", " + quote(DataColumns.USER_LAST_SEEN.getName()) +
+            ", " + quote(DataColumns.USER_HIDE_FROM_TOPS.getName()) + currencySelect +
+            " FROM " + quote(this.usersTable.getName()) +
+            " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ?" +
+            " ORDER BY " + quote(DataColumns.USER_LAST_SEEN.getName()) + " DESC, " + quote(DataColumns.ID.getName()) + " DESC";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, uuid);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                Integer keepId = null;
+                String name = "";
+                String settings = "{}";
+                long lastSeen = 0L;
+                boolean hiddenFromTops = false;
+                int rows = 0;
+                Map<String, Double> balances = new LinkedHashMap<>();
+
+                while (resultSet.next()) {
+                    rows++;
+
+                    if (keepId == null) {
+                        keepId = resultSet.getInt(DataColumns.ID.getName());
+                        name = resultSet.getString(DataColumns.USER_NAME.getName());
+                        settings = resultSet.getString(DataColumns.USER_SETTINGS.getName());
+                        lastSeen = resultSet.getLong(DataColumns.USER_LAST_SEEN.getName());
+                        hiddenFromTops = resultSet.getBoolean(DataColumns.USER_HIDE_FROM_TOPS.getName());
+                    }
+
+                    for (ExcellentCurrency currency : currencies) {
+                        String column = DataColumns.forCurrency(currency).getName();
+                        double value = resultSet.getDouble(column);
+                        if (resultSet.wasNull()) continue;
+
+                        balances.merge(column, value, Math::max);
+                    }
+                }
+
+                if (keepId == null) return null;
+
+                return new MergeState(keepId, Math.max(0, rows - 1), name, settings == null ? "{}" : settings,
+                    lastSeen, hiddenFromTops, balances);
+            }
+        }
+    }
+
+    private void updateMergedUser(@NonNull Connection connection,
+                                  @NonNull MergeState state,
+                                  @NonNull Collection<ExcellentCurrency> currencies) throws SQLException {
+        String balanceAssignments = currencies.stream()
+            .map(currency -> quote(DataColumns.forCurrency(currency).getName()) + " = ?")
+            .collect(Collectors.joining(", "));
+        String balancesSql = balanceAssignments.isEmpty() ? "" : ", " + balanceAssignments;
+
+        String sql = "UPDATE " + quote(this.usersTable.getName()) + " SET " +
+            quote(DataColumns.USER_NAME.getName()) + " = ?, " +
+            quote(DataColumns.USER_SETTINGS.getName()) + " = ?, " +
+            quote(DataColumns.USER_LAST_SEEN.getName()) + " = ?, " +
+            quote(DataColumns.USER_HIDE_FROM_TOPS.getName()) + " = ?" + balancesSql +
+            " WHERE " + quote(DataColumns.ID.getName()) + " = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            int index = 1;
+            statement.setString(index++, state.name());
+            statement.setString(index++, state.settings());
+            statement.setLong(index++, state.lastSeen());
+            statement.setBoolean(index++, state.hiddenFromTops());
+
+            for (ExcellentCurrency currency : currencies) {
+                String column = DataColumns.forCurrency(currency).getName();
+                statement.setDouble(index++, state.balances().getOrDefault(column, currency.getStartValue()));
+            }
+
+            statement.setInt(index, state.keepId());
+            statement.executeUpdate();
+        }
+    }
+
+    private void deleteDuplicateRows(@NonNull Connection connection, @NonNull String uuid, int keepId) throws SQLException {
+        String sql = "DELETE FROM " + quote(this.usersTable.getName()) +
+            " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ?" +
+            " AND " + quote(DataColumns.ID.getName()) + " <> ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, uuid);
+            statement.setInt(2, keepId);
+            statement.executeUpdate();
+        }
+    }
+
+    @NonNull
+    public OptionalDouble fetchBalance(@NonNull UUID uuid, @NonNull ExcellentCurrency currency) {
+        if (!this.isAtomicBalances()) return OptionalDouble.empty();
+
+        try (Connection connection = this.getConnection()) {
+            return this.selectBalance(connection, uuid, currency);
+        }
+        catch (SQLException exception) {
+            exception.printStackTrace();
+            return OptionalDouble.empty();
+        }
+    }
+
+    @NonNull
+    public BalanceResult addBalance(@NonNull CoinsUser user, @NonNull ExcellentCurrency currency, double amount) {
+        return this.updateBalanceDelta(user.getId(), currency, Math.abs(amount), user.getBalance(currency));
+    }
+
+    @NonNull
+    public BalanceResult removeBalance(@NonNull CoinsUser user, @NonNull ExcellentCurrency currency, double amount) {
+        return this.updateBalanceDelta(user.getId(), currency, -Math.abs(amount), user.getBalance(currency));
+    }
+
+    @NonNull
+    public BalanceResult withdrawBalance(@NonNull CoinsUser user, @NonNull ExcellentCurrency currency, double amount) {
+        double positiveAmount = Math.abs(amount);
+        String column = quote(DataColumns.forCurrency(currency).getName());
+        String sql = "UPDATE " + quote(this.usersTable.getName()) +
+            " SET " + column + " = " + column + " - ?" +
+            " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ? AND " + column + " >= ?";
+
+        try (Connection connection = this.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setDouble(1, positiveAmount);
+            statement.setString(2, user.getId().toString());
+            statement.setDouble(3, positiveAmount);
+
+            if (statement.executeUpdate() <= 0) {
+                OptionalDouble balance = this.selectBalance(connection, user.getId(), currency);
+                return balance.isPresent() ? BalanceResult.insufficient(balance.getAsDouble()) : BalanceResult.missing();
+            }
+
+            OptionalDouble balance = this.selectBalance(connection, user.getId(), currency);
+            return balance.isPresent() ? BalanceResult.success(balance.getAsDouble()) : BalanceResult.missing();
+        }
+        catch (SQLException exception) {
+            exception.printStackTrace();
+            return BalanceResult.failure(user.getBalance(currency));
+        }
+    }
+
+    @NonNull
+    public BalanceResult setBalance(@NonNull CoinsUser user, @NonNull ExcellentCurrency currency, double amount) {
+        double balance = currency.floorAndLimit(amount);
+        String column = quote(DataColumns.forCurrency(currency).getName());
+        String sql = "UPDATE " + quote(this.usersTable.getName()) +
+            " SET " + column + " = ?" +
+            " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ?";
+
+        try (Connection connection = this.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setDouble(1, balance);
+            statement.setString(2, user.getId().toString());
+            statement.executeUpdate();
+
+            OptionalDouble fetched = this.selectBalance(connection, user.getId(), currency);
+            return fetched.isPresent() ? BalanceResult.success(fetched.getAsDouble()) : BalanceResult.missing();
+        }
+        catch (SQLException exception) {
+            exception.printStackTrace();
+            return BalanceResult.failure(user.getBalance(currency));
+        }
+    }
+
+    @NonNull
+    public TransferResult transfer(@NonNull CoinsUser source,
+                                   @NonNull CoinsUser target,
+                                   @NonNull ExcellentCurrency currency,
+                                   double amount) {
+        double positiveAmount = Math.abs(amount);
+        String column = quote(DataColumns.forCurrency(currency).getName());
+
+        try (Connection connection = this.getConnection()) {
+            boolean autoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(false);
+
+            try {
+                String withdrawSql = "UPDATE " + quote(this.usersTable.getName()) +
+                    " SET " + column + " = " + column + " - ?" +
+                    " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ? AND " + column + " >= ?";
+
+                try (PreparedStatement statement = connection.prepareStatement(withdrawSql)) {
+                    statement.setDouble(1, positiveAmount);
+                    statement.setString(2, source.getId().toString());
+                    statement.setDouble(3, positiveAmount);
+
+                    if (statement.executeUpdate() <= 0) {
+                        OptionalDouble sourceBalance = this.selectBalance(connection, source.getId(), currency);
+                        connection.rollback();
+                        connection.setAutoCommit(autoCommit);
+                        return sourceBalance.isPresent()
+                            ? TransferResult.insufficient(sourceBalance.getAsDouble(), target.getBalance(currency))
+                            : TransferResult.missing(source.getBalance(currency), target.getBalance(currency));
+                    }
+                }
+
+                String depositSql = "UPDATE " + quote(this.usersTable.getName()) +
+                    " SET " + column + " = GREATEST(0, " + column + " + ?)" +
+                    " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ?";
+
+                try (PreparedStatement statement = connection.prepareStatement(depositSql)) {
+                    statement.setDouble(1, positiveAmount);
+                    statement.setString(2, target.getId().toString());
+
+                    if (statement.executeUpdate() <= 0) {
+                        connection.rollback();
+                        connection.setAutoCommit(autoCommit);
+                        return TransferResult.missing(source.getBalance(currency), target.getBalance(currency));
+                    }
+                }
+
+                double sourceBalance = this.selectBalance(connection, source.getId(), currency).orElse(0D);
+                double targetBalance = this.selectBalance(connection, target.getId(), currency).orElse(0D);
+
+                connection.commit();
+                connection.setAutoCommit(autoCommit);
+                return TransferResult.success(sourceBalance, targetBalance);
+            }
+            catch (SQLException exception) {
+                connection.rollback();
+                connection.setAutoCommit(autoCommit);
+                throw exception;
+            }
+        }
+        catch (SQLException exception) {
+            exception.printStackTrace();
+            return TransferResult.failure(source.getBalance(currency), target.getBalance(currency));
+        }
+    }
+
+    @NonNull
+    public TransferResult exchange(@NonNull CoinsUser user,
+                                   @NonNull ExcellentCurrency sourceCurrency,
+                                   @NonNull ExcellentCurrency targetCurrency,
+                                   double amount,
+                                   double result) {
+        String sourceColumn = quote(DataColumns.forCurrency(sourceCurrency).getName());
+        String targetColumn = quote(DataColumns.forCurrency(targetCurrency).getName());
+        String limitWhere = targetCurrency.isLimited() ? " AND " + targetColumn + " + ? <= ?" : "";
+
+        String sql = "UPDATE " + quote(this.usersTable.getName()) +
+            " SET " + sourceColumn + " = " + sourceColumn + " - ?, " +
+            targetColumn + " = " + targetColumn + " + ?" +
+            " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ? AND " + sourceColumn + " >= ?" + limitWhere;
+
+        try (Connection connection = this.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            int index = 1;
+            statement.setDouble(index++, amount);
+            statement.setDouble(index++, result);
+            statement.setString(index++, user.getId().toString());
+            statement.setDouble(index++, amount);
+
+            if (targetCurrency.isLimited()) {
+                statement.setDouble(index++, result);
+                statement.setDouble(index, targetCurrency.getMaxValue());
+            }
+
+            if (statement.executeUpdate() <= 0) {
+                OptionalDouble sourceBalance = this.selectBalance(connection, user.getId(), sourceCurrency);
+                OptionalDouble targetBalance = this.selectBalance(connection, user.getId(), targetCurrency);
+
+                if (sourceBalance.isEmpty() || targetBalance.isEmpty()) {
+                    return TransferResult.missing(user.getBalance(sourceCurrency), user.getBalance(targetCurrency));
+                }
+                if (sourceBalance.getAsDouble() < amount) {
+                    return TransferResult.insufficient(sourceBalance.getAsDouble(), targetBalance.getAsDouble());
+                }
+                if (targetCurrency.isLimited() && targetBalance.getAsDouble() + result > targetCurrency.getMaxValue()) {
+                    return TransferResult.limit(sourceBalance.getAsDouble(), targetBalance.getAsDouble());
+                }
+                return TransferResult.failure(sourceBalance.getAsDouble(), targetBalance.getAsDouble());
+            }
+
+            double sourceBalance = this.selectBalance(connection, user.getId(), sourceCurrency).orElse(0D);
+            double targetBalance = this.selectBalance(connection, user.getId(), targetCurrency).orElse(0D);
+            return TransferResult.success(sourceBalance, targetBalance);
+        }
+        catch (SQLException exception) {
+            exception.printStackTrace();
+            return TransferResult.failure(user.getBalance(sourceCurrency), user.getBalance(targetCurrency));
+        }
+    }
+
+    @NonNull
+    private BalanceResult updateBalanceDelta(@NonNull UUID uuid,
+                                             @NonNull ExcellentCurrency currency,
+                                             double delta,
+                                             double fallback) {
+        String column = quote(DataColumns.forCurrency(currency).getName());
+        String operator = delta >= 0D ? "+" : "-";
+        String sql = "UPDATE " + quote(this.usersTable.getName()) +
+            " SET " + column + " = GREATEST(0, " + column + " " + operator + " ?)" +
+            " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ?";
+
+        try (Connection connection = this.getConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setDouble(1, Math.abs(delta));
+            statement.setString(2, uuid.toString());
+            statement.executeUpdate();
+
+            OptionalDouble balance = this.selectBalance(connection, uuid, currency);
+            return balance.isPresent() ? BalanceResult.success(balance.getAsDouble()) : BalanceResult.missing();
+        }
+        catch (SQLException exception) {
+            exception.printStackTrace();
+            return BalanceResult.failure(fallback);
+        }
+    }
+
+    @NonNull
+    private OptionalDouble selectBalance(@NonNull Connection connection,
+                                         @NonNull UUID uuid,
+                                         @NonNull ExcellentCurrency currency) throws SQLException {
+        String sql = "SELECT " + quote(DataColumns.forCurrency(currency).getName()) +
+            " FROM " + quote(this.usersTable.getName()) +
+            " WHERE " + quote(DataColumns.USER_UUID.getName()) + " = ? LIMIT 1";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, uuid.toString());
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) return OptionalDouble.empty();
+
+                return OptionalDouble.of(Math.max(0D, resultSet.getDouble(1)));
+            }
+        }
+    }
+
     @Override
     @NonNull
     public Table getUsersTable() {
@@ -126,7 +549,7 @@ public class DataHandler extends AbstractDatabaseManager<EconomyPlugin> implemen
     @Override
     @NonNull
     public UpdateStatement<CoinsUser> getUserUpdateStatement() {
-        return DataQueries.userUpdate();
+        return DataQueries.userUpdate(!this.isAtomicBalances());
     }
 
     @Override
@@ -146,6 +569,89 @@ public class DataHandler extends AbstractDatabaseManager<EconomyPlugin> implemen
             builder.setDouble(DataColumns.forCurrency(currency), o -> currency.getStartValue());
         }
 
-        this.update(this.usersTable, builder.build(), currencies);
+        this.update(this.usersTable, builder.build(), new Object());
+    }
+
+    @NonNull
+    private static String quote(@NonNull String identifier) {
+        return "`" + identifier.replace("`", "``") + "`";
+    }
+
+    private record MergeState(
+        int keepId,
+        int duplicates,
+        @NonNull String name,
+        @NonNull String settings,
+        long lastSeen,
+        boolean hiddenFromTops,
+        @NonNull Map<String, Double> balances
+    ) {
+    }
+
+    public enum BalanceStatus {
+        SUCCESS,
+        FAILURE,
+        INSUFFICIENT_FUNDS,
+        LIMIT_EXCEEDED,
+        MISSING_ACCOUNT
+    }
+
+    public record BalanceResult(@NonNull BalanceStatus status, double balance) {
+
+        public boolean success() {
+            return this.status == BalanceStatus.SUCCESS;
+        }
+
+        @NonNull
+        public static BalanceResult success(double balance) {
+            return new BalanceResult(BalanceStatus.SUCCESS, balance);
+        }
+
+        @NonNull
+        public static BalanceResult failure(double balance) {
+            return new BalanceResult(BalanceStatus.FAILURE, balance);
+        }
+
+        @NonNull
+        public static BalanceResult insufficient(double balance) {
+            return new BalanceResult(BalanceStatus.INSUFFICIENT_FUNDS, balance);
+        }
+
+        @NonNull
+        public static BalanceResult missing() {
+            return new BalanceResult(BalanceStatus.MISSING_ACCOUNT, 0D);
+        }
+    }
+
+    public record TransferResult(@NonNull BalanceStatus status, double sourceBalance, double targetBalance) {
+
+        public boolean success() {
+            return this.status == BalanceStatus.SUCCESS;
+        }
+
+        @NonNull
+        public static TransferResult success(double sourceBalance, double targetBalance) {
+            return new TransferResult(BalanceStatus.SUCCESS, sourceBalance, targetBalance);
+        }
+
+        @NonNull
+        public static TransferResult failure(double sourceBalance, double targetBalance) {
+            return new TransferResult(BalanceStatus.FAILURE, sourceBalance, targetBalance);
+        }
+
+        @NonNull
+        public static TransferResult insufficient(double sourceBalance, double targetBalance) {
+            return new TransferResult(BalanceStatus.INSUFFICIENT_FUNDS, sourceBalance, targetBalance);
+        }
+
+        @NonNull
+        public static TransferResult limit(double sourceBalance, double targetBalance) {
+            return new TransferResult(BalanceStatus.LIMIT_EXCEEDED, sourceBalance, targetBalance);
+        }
+
+        @NonNull
+        public static TransferResult missing(double sourceBalance, double targetBalance) {
+            return new TransferResult(BalanceStatus.MISSING_ACCOUNT, sourceBalance, targetBalance);
+        }
     }
 }

--- a/src/main/java/su/nightexpress/excellenteconomy/data/DataQueries.java
+++ b/src/main/java/su/nightexpress/excellenteconomy/data/DataQueries.java
@@ -74,20 +74,27 @@ public class DataQueries {
             builder.setDouble(column, user -> user.getBalance().get(id));
         });
 
-        return builder.build();
+        return builder.ignoreDuplications().build();
     }
 
     @NonNull
     public static UpdateStatement<CoinsUser> userUpdate() {
+        return userUpdate(true);
+    }
+
+    @NonNull
+    public static UpdateStatement<CoinsUser> userUpdate(boolean includeBalances) {
         var builder = UpdateStatement.<CoinsUser>builder()
             .setString(DataColumns.USER_NAME, CoinsUser::getName)
             .setString(DataColumns.USER_SETTINGS, user -> DataHandler.GSON.toJson(user.getSettingsMap()))
             .setLong(DataColumns.USER_LAST_SEEN, CoinsUser::getLastSeen)
             .setBoolean(DataColumns.USER_HIDE_FROM_TOPS, CoinsUser::isHiddenFromTops);
 
-        DataColumns.currencies().forEach((id, column) -> {
-            builder.setDouble(column, user -> user.getBalance().get(id));
-        });
+        if (includeBalances) {
+            DataColumns.currencies().forEach((id, column) -> {
+                builder.setDouble(column, user -> user.getBalance().get(id));
+            });
+        }
 
         return builder.build();
     }

--- a/src/main/java/su/nightexpress/excellenteconomy/migration/MigrationManager.java
+++ b/src/main/java/su/nightexpress/excellenteconomy/migration/MigrationManager.java
@@ -125,7 +125,7 @@ public class MigrationManager extends SimpleManager<EconomyPlugin> {
             }
 
             user.setBalance(currency, amount);
-            user.markDirty();
+            this.currencyManager.persistBalance(user, currency);
         });
     }
 

--- a/src/main/java/su/nightexpress/excellenteconomy/user/CoinsUser.java
+++ b/src/main/java/su/nightexpress/excellenteconomy/user/CoinsUser.java
@@ -49,6 +49,10 @@ public class CoinsUser extends UserTemplate {
      * @param consumer balance function.
      */
     public void editBalance(@NonNull ExcellentCurrency currency, @NonNull Consumer<UserBalance> consumer) {
+        this.tryEditBalance(currency, consumer);
+    }
+
+    public boolean tryEditBalance(@NonNull ExcellentCurrency currency, @NonNull Consumer<UserBalance> consumer) {
         double oldBalance = this.getBalance(currency);
 
         consumer.accept(this.balance);
@@ -58,7 +62,10 @@ public class CoinsUser extends UserTemplate {
 
         if (event.isCancelled()) {
             this.balance.set(currency, oldBalance);
+            return false;
         }
+
+        return true;
     }
 
     public void resetBalance(@NonNull Collection<ExcellentCurrency> currencies) {
@@ -67,6 +74,10 @@ public class CoinsUser extends UserTemplate {
 
     public void resetBalance(@NonNull ExcellentCurrency currency) {
         this.editBalance(currency, bal -> bal.set(currency, currency.getStartValue()));
+    }
+
+    public boolean tryResetBalance(@NonNull ExcellentCurrency currency) {
+        return this.tryEditBalance(currency, bal -> bal.set(currency, currency.getStartValue()));
     }
 
     public boolean hasEnough(@NonNull ExcellentCurrency currency, double amount) {
@@ -81,12 +92,24 @@ public class CoinsUser extends UserTemplate {
         this.editBalance(currency, bal -> bal.add(currency, amount));
     }
 
+    public boolean tryAddBalance(@NonNull ExcellentCurrency currency, double amount) {
+        return this.tryEditBalance(currency, bal -> bal.add(currency, amount));
+    }
+
     public void removeBalance(@NonNull ExcellentCurrency currency, double amount) {
         this.editBalance(currency, lookup -> lookup.remove(currency, amount));
     }
 
+    public boolean tryRemoveBalance(@NonNull ExcellentCurrency currency, double amount) {
+        return this.tryEditBalance(currency, lookup -> lookup.remove(currency, amount));
+    }
+
     public void setBalance(@NonNull ExcellentCurrency currency, double amount) {
         this.editBalance(currency, lookup -> lookup.set(currency, amount));
+    }
+
+    public boolean trySetBalance(@NonNull ExcellentCurrency currency, double amount) {
+        return this.tryEditBalance(currency, lookup -> lookup.set(currency, amount));
     }
 
     @NonNull


### PR DESCRIPTION
## Summary

This PR improves balance consistency when ExcellentEconomy is used with MySQL across multiple servers.

Previously, balances were updated in local memory and later saved through dirty user-data updates. In a high-concurrency multi-server setup, this could allow stale cached balances to overwrite newer values, cause race conditions during player payments, or create duplicate user rows during concurrent first-login inserts.

